### PR TITLE
service-side result tracking with historical summary

### DIFF
--- a/ocp/framework/client/resultProcessingClient.py
+++ b/ocp/framework/client/resultProcessingClient.py
@@ -243,15 +243,12 @@ class ResultProcessingClientFactory(sharedClient.ServiceClientFactory):
 
 	def startProcessing(self):
 		"""Starts kafka processessing."""
-		print('Inside startProcessing...')
 		threadHandle = None
 		try:
 			## Prepare for our maintenance work (no-op on first run)...
 			self.maintenanceMode = True
-			print('startProcessing: while not canceled loop')
 			## Initialize the Kafka connection
 			while not self.connectedToKafkaConsumer and not self.canceled:
-				print('startProcessing: calling createKafkaConsumer')
 				self.logger.debug('startProcessing: calling createKafkaConsumer')
 				self.kafkaConsumer = self.createKafkaConsumer(self.kafkaTopic)
 				## You hit an exception if this is the first time the topic is
@@ -262,13 +259,11 @@ class ResultProcessingClientFactory(sharedClient.ServiceClientFactory):
 			## Wait for the previous processKafkaResults to break out of the
 			## while loop and finish, before starting routine maintenance.
 			while not self.pauseKafkaProcessing and not self.canceled:
-				print('startProcessing: inside maintenance wait loop for pauseKafkaProcessing')
 				self.logger.info('startProcessing: inside maintenance wait loop for pauseKafkaProcessing')
 				time.sleep(2)
 
 			## Maintenance work...
 			## Build objectCache from scratch instead of updating from timestamp
-			print('startProcessing: build objectCache from scratch')
 			self.logger.debug('startProcessing: build objectCache from scratch')
 			self.objectCache.build()
 			## Initialize the resultProcessingUtility
@@ -304,7 +299,6 @@ class ResultProcessingClientFactory(sharedClient.ServiceClientFactory):
 
 	def processKafkaResults(self):
 		"""Wait for kafka results, and send into the resultProcessingUtility."""
-		print('Inside processKafkaResults')
 		self.logger.info('Inside {name!r}.processKafkaResults', name=__name__)
 		while self.connectedToKafkaConsumer and not self.maintenanceMode and not self.canceled:
 			try:
@@ -338,7 +332,6 @@ class ResultProcessingClientFactory(sharedClient.ServiceClientFactory):
 				print('Interrrupt received...')
 				self.canceled = True
 			except:
-				print('Exception in processKafkaResults...')
 				exception = traceback.format_exception(sys.exc_info()[0], sys.exc_info()[1], sys.exc_info()[2])
 				self.logger.error('processKafkaResults: exception in kafka wait loop: {exception}', exception=exception)
 				self.logToKafka('processKafkaResults: aborted kafka wait loop')
@@ -353,13 +346,11 @@ class ResultProcessingClientFactory(sharedClient.ServiceClientFactory):
 				self.kafkaErrorCount += 1
 				try:
 					if self.kafkaErrorCount < self.kafkaErrorLimit:
-						print('processKafkaResults kafkaErrorCount {}'.format(self.kafkaErrorCount))
 						with suppress(Exception):
 							self.logger.error('processKafkaResults kafkaErrorCount {kafkaErrorCount}', kafkaErrorCount=self.kafkaErrorCount)
 						time.sleep(2)
 					else:
 						self.canceled = True
-						print('processKafkaResults kafkaErrorCount {}... exiting.'.format(self.kafkaErrorCount))
 						with suppress(Exception):
 							self.logger.error('processKafkaResults kafkaErrorCount {kafkaErrorCount}', kafkaErrorCount=self.kafkaErrorCount)
 						reactor.stop()
@@ -369,11 +360,8 @@ class ResultProcessingClientFactory(sharedClient.ServiceClientFactory):
 					reactor.stop()
 
 		self.resultProcessingUtility = None
-		print('Leaving processKafkaResults...')
 		self.logger.debug('Leaving processKafkaResults...')
-		print('  --> connectedToKafkaConsumer {}'.format(self.connectedToKafkaConsumer))
 		self.logger.debug('  --> connectedToKafkaConsumer {connectedToKafkaConsumer!r}', connectedToKafkaConsumer=self.connectedToKafkaConsumer)
-		print('  --> maintenanceMode  {}'.format(self.maintenanceMode))
 		self.logger.debug('  --> maintenanceMode  {maintenanceMode!r}', maintenanceMode=self.maintenanceMode)
 
 		## Indicate we are ready for cache full sync

--- a/ocp/framework/client/sharedClient.py
+++ b/ocp/framework/client/sharedClient.py
@@ -328,7 +328,7 @@ class ServiceClientFactory(ReconnectingClientFactory):
 		headersAsDict = {}
 		headersAsDict['Content-Type'] = 'application/json'
 		headersAsDict['endpointKey'] = self.endpointKey
-		
+
 		while True:
 			try:
 				## Issue a GET call to URL for token generation

--- a/ocp/framework/database/schema/platformSchema.py
+++ b/ocp/framework/database/schema/platformSchema.py
@@ -818,6 +818,74 @@ class ServiceUniversalJobHealth(EndpointHealthAttributes, Base):
 	name = Column(String(256), primary_key=True)
 
 
+class ContentGatheringServiceResults(Base):
+	"""Defines a service_results_content_gathering object for the database.
+
+	Table :
+	  |  service_results_content_gathering
+	Columns :
+	  |  job [String(256)] PK
+	  |  time_started [DateTime] PK
+	  |  active_client_list [ARRAY]
+	  |  active_client_count [Integer]
+	  |  endpoint_count [Integer]
+	  |  completed_count [Integer]
+	  |  time_finished [DateTime]
+	  |  time_elapsed [Float]
+	  |  job_completed [Boolean]
+	  |  count_per_client [JSON]
+	"""
+
+	__tablename__ = 'service_results_content_gathering'
+	__table_args__ = {"schema":"platform"}
+	job = Column(String(256), primary_key=True)
+	#active_clients = Column(String(512), nullable=False)
+	active_client_list = Column(ARRAY(String, dimensions=1), nullable=False)
+	active_client_count = Column(Integer, default=0)
+	endpoint_count = Column(Integer, default=0)
+	completed_count = Column(Integer, default=0)
+	time_started = Column(DateTime(timezone=True), primary_key=True)
+	time_finished = Column(DateTime(timezone=True), nullable=True)
+	time_elapsed = Column(Float, nullable=True)
+	job_completed = Column(Boolean, default=False)
+	count_per_client = Column(JSON, nullable=False)
+	count_per_status = Column(JSON, nullable=False)
+
+
+class UniversalJobServiceResults(Base):
+	"""Defines a service_results_content_gathering object for the database.
+
+	Table :
+	  |  service_results_universal_job
+	Columns :
+	  |  job [String(256)] PK
+	  |  time_started [DateTime] PK
+	  |  active_client_list [ARRAY]
+	  |  active_client_count [Integer]
+	  |  endpoint_count [Integer]
+	  |  completed_count [Integer]
+	  |  time_finished [DateTime]
+	  |  time_elapsed [Float]
+	  |  job_completed [Boolean]
+	  |  count_per_client [JSON]
+	"""
+
+	__tablename__ = 'service_results_universal_job'
+	__table_args__ = {"schema":"platform"}
+	job = Column(String(256), primary_key=True)
+	#active_clients = Column(String(512), nullable=False)
+	active_client_list = Column(ARRAY(String, dimensions=1), nullable=False)
+	active_client_count = Column(Integer, default=0)
+	endpoint_count = Column(Integer, default=0)
+	completed_count = Column(Integer, default=0)
+	time_started = Column(DateTime(timezone=True), primary_key=True)
+	time_finished = Column(DateTime(timezone=True), nullable=True)
+	time_elapsed = Column(Float, nullable=True)
+	job_completed = Column(Boolean, default=False)
+	count_per_client = Column(JSON, nullable=False)
+	count_per_status = Column(JSON, nullable=False)
+
+
 class ContentGatheringResults(Base):
 	"""Defines a content_gathering_results object for the database.
 

--- a/ocp/framework/service/contentGatheringService.py
+++ b/ocp/framework/service/contentGatheringService.py
@@ -65,6 +65,7 @@ class ContentGatheringService(sharedService.ServiceProcess):
 		self.globalSettings = globalSettings
 		self.clientEndpointTable = platformSchema.ServiceContentGatheringEndpoint
 		self.clientResultsTable = platformSchema.ContentGatheringResults
+		self.serviceResultsTable = platformSchema.ContentGatheringServiceResults
 		self.pkgPath = env.contentGatheringPkgPath
 		self.serviceSettings = globalSettings['fileContainingContentGatheringSettings']
 		self.serviceLogSetup = globalSettings['fileContainingServiceLogSettings']

--- a/ocp/framework/service/sharedService.py
+++ b/ocp/framework/service/sharedService.py
@@ -979,7 +979,7 @@ class ServiceProcess(multiprocessing.Process):
 			## directed by additional input parameters; set args accordingly:
 			factoryArgs = None
 			if (self.serviceName == 'ContentGatheringService' or self.serviceName == 'UniversalJobService'):
-				factoryArgs = (self.serviceName, self.globalSettings, self.canceledEvent, self.shutdownEvent, self.moduleType, self.clientEndpointTable, self.clientResultsTable, self.pkgPath, self.serviceSettings, self.serviceLogSetup)
+				factoryArgs = (self.serviceName, self.globalSettings, self.canceledEvent, self.shutdownEvent, self.moduleType, self.clientEndpointTable, self.clientResultsTable, self.serviceResultsTable, self.pkgPath, self.serviceSettings, self.serviceLogSetup)
 			else:
 				factoryArgs = (self.serviceName, self.globalSettings, self.canceledEvent, self.shutdownEvent)
 

--- a/ocp/framework/service/universalJobService.py
+++ b/ocp/framework/service/universalJobService.py
@@ -70,6 +70,7 @@ class UniversalJobService(sharedService.ServiceProcess):
 		self.globalSettings = globalSettings
 		self.clientEndpointTable = platformSchema.ServiceUniversalJobEndpoint
 		self.clientResultsTable = platformSchema.UniversalJobResults
+		self.serviceResultsTable = platformSchema.UniversalJobServiceResults
 		self.pkgPath = env.universalJobPkgPath
 		self.serviceSettings = globalSettings['fileContainingUniversalJobSettings']
 		self.serviceLogSetup = globalSettings['fileContainingServiceLogSettings']


### PR DESCRIPTION
New DB tables and tracking functions for high-level summaries of job executions. Wanted a table to retain something from previous runs of the client-side jobs, so that the next execution cycle doesn't hide previous problems, enabling post-mortem exercises.