### PR TITLE
adding new testCommand package into contentGathering service

### DIFF
--- a/ocp/content/contentGathering/testCommand/input/shell_with_node_details.json
+++ b/ocp/content/contentGathering/testCommand/input/shell_with_node_details.json
@@ -1,0 +1,30 @@
+{
+	"objects": [{
+			"class_name": <VALUE1>,
+			"attributes": ["object_type", "ipaddress", "protocol_reference", "realm", "container", "node_type", "parameters"],
+			"minimum": "1",
+			"maximum": "",
+			"filter": [{
+				"condition": {
+					"attribute": "ipaddress",
+					"operator": "==",
+					"value": <VALUE2>
+				}
+			}],
+			"linchpin": true
+		},
+		{
+			"class_name": "Node",
+			"attributes": ["hostname", "domain", "vendor", "platform", "version", "hardware_provider"],
+			"minimum": "1",
+			"maximum": "1"
+		}
+	],
+	"links": [{
+		"label": "NODE_TO_SHELL",
+		"class_name": "Enclosed",
+		"attributes": [],
+		"first_id": "Node",
+		"second_id": <VALUE1>
+	}]
+}

--- a/ocp/content/contentGathering/testCommand/job/test_command.json
+++ b/ocp/content/contentGathering/testCommand/job/test_command.json
@@ -1,0 +1,41 @@
+{
+	"jobName" : "test_command",
+	"realm" : "default",
+	"clientGroup" : "default",
+	"protocolType" : ["ProtocolPowerShell", "ProtocolSsh"],
+	"numberOfJobThreads" : 1,
+	"jobScript" : "test_command",
+	"clientOnlyTrigger" : true,
+	"clientEndpoint" : "any",
+	"endpointIdColumn" : "value",
+	"loadConfigGroups" : true,
+	"updateParameters" : true,
+	"isDisabled" : true,
+	"runTimeValues" : {
+		"maxJobRunTime" : 600,
+		"maxProtocolTime" : 600,
+		"maxCommandTime" : 60
+	},
+	"inputParameters" : {
+		"endpointIp" : "192.168.121.142",
+		"inputQuery" : "shell_with_node_details",
+		"commandList" : ["hostname", "Get-Process"],
+		"printDebug" : true
+	},
+	"triggerType" : "interval",
+	"triggerArgs" : {
+		"weeks" : null,
+		"days" : null,
+		"hours" : null,
+		"minutes" : null,
+		"seconds" : 15,
+		"start_date" : "",
+		"end_date" : ""
+	},
+	"schedulerArgs" : {
+		"misfire_grace_time" : 10,
+		"coalesce" : 1,
+		"max_instances" : 1,
+		"replace_existing" : 1
+	}
+}

--- a/ocp/content/contentGathering/testCommand/script/test_command.py
+++ b/ocp/content/contentGathering/testCommand/script/test_command.py
@@ -1,0 +1,164 @@
+"""Run user-provided command on target endpoint.
+
+Troubleshooting aid for troubled endpoint testing.
+
+Author: Chris Satterthwaite (CS)
+Contributors:
+Version info:
+  1.0 : (CS) Created Sep 1, 2020
+
+"""
+import sys
+import traceback
+from contextlib import suppress
+import json
+import os
+import re
+
+## From openContentPlatform
+from protocolWrapper import getClient
+from osProcesses import getProcesses
+from osSoftwarePackages import getSoftwarePackages
+from osStartTasks import getStartTasks
+from utilities import loadConfigGroupFile, compareFilter, getApiResult
+from utilities import getApiQueryResultsFull
+
+## Global for ease of future change
+validShellTypes = ["PowerShell", "SSH"]
+
+
+
+def issueApiCall(runtime):
+	endpoint = None
+	## Get the parameters
+	inputQuery = runtime.parameters.get('inputQuery')
+	targetIp = runtime.parameters.get('endpointIp')
+
+	## Corresponding directory for our input query
+	jobScriptPath = os.path.dirname(os.path.realpath(__file__))
+	jobPath = os.path.abspath(os.path.join(jobScriptPath, '..'))
+
+	## Load the file containing the query
+	queryFile = os.path.join(jobPath, 'input', inputQuery + '.json')
+	if not os.path.isfile(queryFile):
+		raise EnvironmentError('JSON query file does not exist: {}'.format(queryFile))
+	queryContent = None
+	with open(queryFile, 'r') as fp:
+		queryContent = fp.read()
+
+	## We do not know shell type, and in the future there may be more. So we
+	## will loop through each one, trying until we find it.
+
+	## Note: previously this was sent in by the endpoint query, but when we
+	## switched over to make the IP a parameter instead... the shell details are
+	## no longer sent into the job. Hence this step to request from the API.
+	## The idea was to simplify user experience by adding more code.
+	queryResults = None
+	for shellType in validShellTypes:
+		thisQuery = queryContent
+		## Replace <VALUE1> and <VALUE2> placeholders:
+		##   VALUE1 = the shell type: PowerShell or SSH
+		##   VALUE2 = the IP address of the target endpoint you wish to template
+		thisQuery = thisQuery.replace('<VALUE1>', '"{}"'.format(shellType))
+		thisQuery = thisQuery.replace('<VALUE2>', '"{}"'.format(targetIp))
+
+		queryResults = getApiQueryResultsFull(runtime, thisQuery, resultsFormat='Nested', headers={'removeEmptyAttributes': False})
+		if queryResults is not None and len(queryResults[shellType]) > 0:
+			break
+
+	if queryResults is None or len(queryResults[shellType]) <= 0:
+		raise EnvironmentError('Could not find endpoint {} with a correspoinding shell. Please make sure to run the corresponding "Find" job first.'.format(targetIp))
+
+	runtime.logger.report('queryResults: {queryResults!r}...', queryResults=queryResults)
+	## Set the protocol data on runtime, as though it was sent in regularly.
+	## And don't use 'get'; allow exceptions here if endpoint values are missing
+	endpoint = queryResults[shellType][0]
+	runtime.endpoint = {
+		"class_name" : endpoint["class_name"],
+		"identifier" : endpoint["identifier"],
+		"data" : endpoint["data"]
+	}
+	runtime.setParameters()
+
+	return endpoint
+
+
+def getNodeDetails(runtime):
+	"""Pull attributes off the node sent in the endpoint.
+
+	Arguments:
+	  runtime (dict) : object used for providing I/O for jobs and tracking
+	                   the job thread through its runtime.
+	"""
+	nodeDetails = {}
+	endpoint = issueApiCall(runtime)
+
+	## Node should be directly connected to the endpoint linchpin
+	objectsLinkedToLinchpin = endpoint.get('children',{})
+	nodeFound = False
+	hostname = None
+	for objectLabel, objectList in objectsLinkedToLinchpin.items():
+		runtime.logger.report(' looking for Node in related objects label {objectLabel!r}...', objectLabel=objectLabel)
+		for entry in objectList:
+			if 'hostname' not in entry.get('data').keys():
+				break
+			nodeDetails['hostname'] = entry.get('data').get('hostname')
+			nodeDetails['domain'] = entry.get('data').get('domain')
+			nodeDetails['vendor'] = entry.get('data').get('vendor')
+			nodeDetails['platform'] = entry.get('data').get('platform')
+			nodeDetails['version'] = entry.get('data').get('version')
+			nodeDetails['provider'] = entry.get('data').get('hardware_provider')
+			runtime.logger.report(' --> found hostname {hostname!r}: {vendor!r}, {platform!r}, {version!r}, {provider!r}', hostname=nodeDetails['hostname'], vendor=nodeDetails['vendor'], platform=nodeDetails['platform'], version=nodeDetails['version'], provider=nodeDetails['provider'])
+			return nodeDetails
+
+	## end getNodeDetails
+	return
+
+
+def startJob(runtime):
+	"""Standard job entry point.
+
+	Arguments:
+	  runtime (dict) : object used for providing I/O for jobs and tracking
+	                   the job thread through its runtime.
+	"""
+	client = None
+	try:
+		## Issue API query for the node, and get details for creating this entry
+		nodeDetails = getNodeDetails(runtime)
+		if nodeDetails is None:
+			raise EnvironmentError('Unable to pull node details from endpoint.')
+
+		## Get parameters controlling the job
+		commandsToTest = runtime.parameters.get('commandList', [])
+		commandTimeout = runtime.parameters.get('commandTimeout', 10)
+
+		## Configure shell client
+		client = getClient(runtime)
+		if client is not None:
+			## Open client session before starting the work
+			client.open()
+
+			## Run commands
+			for command in commandsToTest:
+				runtime.logger.warn('Running command: {command!r}', command=command)
+				(stdOut, stdError, hitProblem) = client.run(command, commandTimeout)
+				if hitProblem:
+					runtime.logger.warn(' command encountered a problem')
+				else:
+					runtime.logger.warn(' command successful')
+				runtime.logger.warn('  stdOut: {stdOut!r}', stdOut=stdOut)
+				runtime.logger.warn('  stdError: {stdError!r}', stdError=stdError)
+
+			## Update the runtime status to success
+			runtime.status(1)
+
+	except:
+		runtime.setError(__name__)
+
+	with suppress(Exception):
+		if client is not None:
+			client.close()
+
+	## end startJob
+	return

--- a/ocp/framework/lib/contentManagement.py
+++ b/ocp/framework/lib/contentManagement.py
@@ -123,7 +123,8 @@ def updatePackage(pkgName, pkgSystem='contentGathering', pkgPath=None, forceUpda
 
 		else:
 			## First time load of the package into the database
-			logger.info('Attempting to update a package that did not previously exist in the database. Please compress and then add the package first.')
+			logger.error('Attempting to update a package that did not previously exist in the database. Please compress and then add the package first.')
+			print('Attempting to update a package that did not previously exist in the database. Please compress and then add the package first.')
 
 		## Cleanup
 		logger.info('Finished content management work on package {}; cleaning up.'.format(pkgName))
@@ -682,8 +683,8 @@ Usage:  python {} <option> [parameters]
        filesystem. The <system> parameter should be one of the following values:
        'contentGathering', 'universal', 'serverSide'. The <fullyQualifiedPath>
        parameter defaults to the server's ./content/<system>/<packageName> path,
-       if not specified. If a package by the same name already exists, it is
-       updated; otherwise it is created new.
+       if not specified. When using the uncompressed option, the package must
+       already exist; if it does not yet exist, use the compressed option first.
 
     -baseline
        Re-runs the loading of all packages into the database, from the server's


### PR DESCRIPTION
This enables the testing of commands on a target endpoint. The commands are transformed/updated as the framework would do normally in another job, but this allows tactical testing of environmental differences, like elevated account access and command output variance across target endpoints... without continuing to rerun a standard job.