### PR TITLE
Job execution logs sent to server

### DIFF
--- a/ocp/framework/client/jobClient.py
+++ b/ocp/framework/client/jobClient.py
@@ -237,6 +237,7 @@ class JobClientFactory(coreClient.ServiceClientFactory):
 			self.clientSettings = utils.loadSettings(os.path.join(env.configPath, globalSettings['fileContainingJobClientConfig']))
 			self.clientGroups = { 'clientGroups' : self.clientSettings.get('clientGroups', []) }
 			self.kafkaTopic = globalSettings['kafkaTopic']
+			self.kafkaLogForJobsTopic = globalSettings['kafkaLogForJobsTopic']
 			self.kafkaConsumerErrorLimit = self.localSettings['kafkaConsumerErrorLimit']
 			self.kafkaProducer = None
 			self.requiresRestart = False
@@ -486,7 +487,7 @@ class JobClientFactory(coreClient.ServiceClientFactory):
 		numberOfJobThreads = int(jobMetaData['numberOfJobThreads'])
 		self.logger.info('Spinning up {numberOfJobThreads!r} threads for job {jobName!r}', numberOfJobThreads=numberOfJobThreads, jobName=jobName)
 		for i in range(int(numberOfJobThreads)):
-			activeThread = RemoteThread(self.dStatusLogger, self.dDetailLogger, env, jobShortName, packageName, scriptName, jobMetaData, protocolType, inputParameters, protocols, shellConfig, self.jobEndpoints[jobName], self.jobStatistics[jobName], self.kafkaProducer, self.kafkaTopic)
+			activeThread = RemoteThread(self.dStatusLogger, self.dDetailLogger, env, jobShortName, packageName, scriptName, jobMetaData, protocolType, inputParameters, protocols, shellConfig, self.jobEndpoints[jobName], self.jobStatistics[jobName], self.kafkaProducer, self.kafkaTopic, self.kafkaLogForJobsTopic)
 			activeThread.start()
 			self.jobThreads[jobName].append(activeThread)
 

--- a/ocp/framework/lib/apiResourceData.py
+++ b/ocp/framework/lib/apiResourceData.py
@@ -29,9 +29,6 @@ import utils
 import database.connectionPool as tableMapping
 from apiHugWrapper import hugWrapper
 from apiResourceUtils import *
-## Load the global settings
-import env
-globalSettings = utils.loadSettings(os.path.join(env.configPath, "globalSettings.json"))
 
 
 @hugWrapper.get('/')

--- a/ocp/framework/lib/apiResourceRoot.py
+++ b/ocp/framework/lib/apiResourceRoot.py
@@ -129,6 +129,7 @@ class VariableAndLoggerMiddleware:
 			request.context['kafkaCertificateFile'] = self.globalSettings['kafkaCertificateFile']
 			request.context['kafkaKeyFile'] = self.globalSettings['kafkaKeyFile']
 			request.context['envConfigPath'] = self.env.configPath
+			request.context['envLogPath'] = self.env.logPath
 			request.context['envApiQueryPath'] = self.env.apiQueryPath
 			request.context['envContentGatheringSharedConfigGroupPath'] = self.env.contentGatheringSharedConfigGroupPath
 			## Create an errors section so we can simply append within functions

--- a/ocp/framework/service/coreService.py
+++ b/ocp/framework/service/coreService.py
@@ -468,7 +468,7 @@ class CoreService():
 						self.logger.debug('getKafkaResults: Kafka error: {error!r}', error=message.error())
 						continue
 					thisMsg = json.loads(message.value().decode('utf-8'))
-					self.logger.debug('Data received for processing: {thisMsg!r}', thisMsg=thisMsg)
+					#self.logger.debug('Data received for processing: {thisMsg!r}', thisMsg=thisMsg)
 					self.workOnMessage(thisMsg)
 
 			except:

--- a/ocp/framework/service/jobService.py
+++ b/ocp/framework/service/jobService.py
@@ -887,10 +887,13 @@ class JobServiceFactory(networkService.ServiceFactory):
 			if clientName in self.jobActiveClients[jobName]:
 				self.logger.info('removeClientFromAllActiveJobs: removing client {clientName!r} from job {jobName!r}', clientName=clientName, jobName=jobName)
 				self.jobActiveClients[jobName].remove(clientName)
-				## If all the clients reported back in, shut it down
-				if len(self.jobActiveClients[jobName]) <= 0:
-					self.logger.info('removeClientFromAllActiveJobs: calling doJobComplete for job {jobName!r}', jobName=jobName)
-					self.doJobComplete(jobName)
+		## Using a second loop to check this, in case of unclean disconnects;
+		## force-stop jobs without clients... they won't progress or finish.
+		for jobName in list(self.jobActiveClients.keys()):
+			## If all the clients reported back in, shut it down
+			if len(self.jobActiveClients[jobName]) <= 0:
+				self.logger.info('removeClientFromAllActiveJobs: calling doJobComplete for job {jobName!r}', jobName=jobName)
+				self.doJobComplete(jobName)
 
 		## end removeClientFromAllActiveJobs
 		return

--- a/ocp/framework/service/logCollectionForJobsService.py
+++ b/ocp/framework/service/logCollectionForJobsService.py
@@ -97,7 +97,15 @@ class LogCollectionForJobs(localService.LocalService):
 		endpoint = message['endpoint']
 		content = message['content']
 		self.logger.info('Received message from: {packageName!r}.{jobName!r}.{endpointName!r}',
-						 packageName=packageName, jobName=jobName, endpointName=endpointName)
+						 packageName=packageName, jobName=jobName, endpointName=endpoint)
+
+		## Write to ./runtime/log/job/<jobName>/<endpoint>.log
+		logPath = os.path.join(env.logPath, 'job', jobName)
+		if not os.path.exists(logPath):
+			os.makedirs(logPath)
+		exectutionLogFile = os.path.join(logPath, '{}.log'.format(endpoint))
+		with open(exectutionLogFile, 'w') as fh:
+			fh.write(content)
 
 		## end workOnMessage
 		return


### PR DESCRIPTION
Enabling the 'createExecutionLog' job attribute to allow individual client-side logs to be sent back to the server and then exposed via the API.