### PR TITLE
remove double filter on tcp client port dups

### DIFF
--- a/ocp/content/contentGathering/dynamicDiscovery/script/shell_app_components_vocal.py
+++ b/ocp/content/contentGathering/dynamicDiscovery/script/shell_app_components_vocal.py
@@ -203,7 +203,10 @@ def createEstablishedRemotePort(runtime, data, serverIp, serverPort, clientIp):
 		runtime.logger.report(' createEstablishedRemotePort tcpPorts1:  tcpIpPortId {tcpIpPortId!r} - tcpIpPortClientId {tcpIpPortClientId!r}', tcpIpPortId=tcpIpPortId, tcpIpPortClientId=tcpIpPortClientId)
 		if tcpIpPortId is None or tcpIpPortClientId is None:
 			runtime.logger.report('   Creating Server TcpIpPort {serverEndpoint!r}', serverEndpoint=serverEndpoint)
-			(tcpIpPortId, tcpIpPortClientId) = osNetworkStack.addTcpPort(runtime, 'tcp', serverIp, serverPort, data.trackedIPs, clientIP=clientIp)
+			## Not using avoidDuplicates here; we do a better job with directly
+			## managing the keys in data.clientPorts above, instead of having to
+			## do after-the-fact lookups in the runtime.results.
+			(tcpIpPortId, tcpIpPortClientId) = osNetworkStack.addTcpPort(runtime, 'tcp', serverIp, serverPort, data.trackedIPs, clientIP=clientIp, avoidDuplicates=False)
 			runtime.logger.report(' createEstablishedRemotePort tcpPorts2:  tcpIpPortId {tcpIpPortId!r} - tcpIpPortClientId {tcpIpPortClientId!r}', tcpIpPortId=tcpIpPortId, tcpIpPortClientId=tcpIpPortClientId)
 			## Update the port dictionaries
 			if tcpIpPortId is not None:

--- a/ocp/framework/client/coreClient.py
+++ b/ocp/framework/client/coreClient.py
@@ -222,6 +222,7 @@ class ServiceClientFactory(ReconnectingClientFactory):
 		self.numPortsChanged = False
 		self.disconnectedOnPurpose = False
 
+		self.dbClient = None
 		if getDbClient:
 			self.getDbSession()
 
@@ -439,7 +440,7 @@ class ServiceClientFactory(ReconnectingClientFactory):
 	@logExceptionWithSelfLogger()
 	def updateExecutionEnvironment(self, data):
 		content = self.executionEnvironment['runtime']
-		## Mutate in place in case of references
+		## Mutate in place and in the main thread
 		content.clear()
 		for key,value in data.items():
 			content[key] = value
@@ -473,6 +474,7 @@ class ServiceClientFactory(ReconnectingClientFactory):
 			exception = traceback.format_exception(sys.exc_info()[0], sys.exc_info()[1], sys.exc_info()[2])
 			self.logger.error('Exception: {exception!r}', exception=exception)
 			self.logger.error('AccessDenied errors on Windows usually mean the client was not started as Administrator.')
+			print('AccessDenied errors for environment usually mean the client was not started as Administrator; please run with an elevated account.')
 
 		except:
 			exception = traceback.format_exception(sys.exc_info()[0], sys.exc_info()[1], sys.exc_info()[2])


### PR DESCRIPTION
The osNetworkStack script had a best guess method to remove dups, when the dynamic discovery was already doing it. The double filter caused client ports to be merged.