### PR TITLE
doWrite on Twisted Tcp Port

### DIFF
--- a/ocp/framework/lib/resultProcessing.py
+++ b/ocp/framework/lib/resultProcessing.py
@@ -21,7 +21,6 @@ import json
 import time
 import uuid
 import datetime
-from twisted.internet import reactor, task
 import twisted.logger
 from contextlib import suppress
 from sqlalchemy.orm import noload

--- a/ocp/framework/service/apiService.py
+++ b/ocp/framework/service/apiService.py
@@ -35,11 +35,6 @@ import sys
 import traceback
 import twisted.logger
 from contextlib import suppress
-from twisted.internet import reactor, ssl
-from twisted.python.filepath import FilePath
-from twisted.web.server import Site
-from twisted.web.wsgi import WSGIResource
-from twisted.python.threadpool import ThreadPool
 import multiprocessing
 
 ## Different logger options
@@ -156,6 +151,13 @@ class ApiService(multiprocessing.Process):
 		"""
 		## Setup requested log handler
 		try:
+			## Twisted imports here to avoid issues with epoll on Linux
+			from twisted.internet import reactor, ssl
+			from twisted.python.filepath import FilePath
+			from twisted.web.server import Site
+			from twisted.web.wsgi import WSGIResource
+			from twisted.python.threadpool import ThreadPool
+
 			print('Starting {}'.format(self.serviceName))
 			self.getLocalLogger()
 			self.logger.info('Starting {}'.format(self.serviceName))

--- a/ocp/framework/service/coreService.py
+++ b/ocp/framework/service/coreService.py
@@ -41,10 +41,9 @@ import platform
 import psutil
 import multiprocessing
 from contextlib import suppress
-from twisted.internet import reactor, threads, task, threads
 from sqlalchemy import exc
 from confluent_kafka import KafkaError
-
+from twisted.internet import threads
 ## Add openContentPlatform directories onto the sys path
 import env
 env.addLibPath()
@@ -71,6 +70,9 @@ class CoreService():
 			if getDbClient:
 				self.getDbSession()
 			self.baselineEnvironment()
+
+			## Twisted import here to avoid issues with epoll on Linux
+			from twisted.internet import reactor, task
 
 			#self.loopingHealthCheck = task.LoopingCall(self.healthCheck)
 			self.loopingHealthCheck = task.LoopingCall(self.deferHealthCheck)

--- a/ocp/framework/service/localService.py
+++ b/ocp/framework/service/localService.py
@@ -24,7 +24,6 @@ import platform
 import psutil
 import multiprocessing
 from contextlib import suppress
-from twisted.internet import reactor, task, defer
 from sqlalchemy import exc
 from confluent_kafka import KafkaError
 
@@ -63,6 +62,9 @@ class ServiceProcess(multiprocessing.Process):
 
 		"""
 		try:
+			## Twisted import here to avoid issues with epoll on Linux
+			from twisted.internet import reactor
+
 			## There are two types of event handlers being used here:
 			##   self.shutdownEvent : main process tells this one to shutdown
 			##                        (e.g. on a Ctrl+C type event)

--- a/ocp/framework/service/logCollectionForJobsService.py
+++ b/ocp/framework/service/logCollectionForJobsService.py
@@ -22,7 +22,7 @@ import json
 import time
 from contextlib import suppress
 import twisted.logger
-from twisted.internet import reactor, task, defer, threads
+from twisted.internet import threads
 
 ## Add openContentPlatform directories onto the sys path
 import env
@@ -49,6 +49,9 @@ class LogCollectionForJobs(localService.LocalService):
 		self.localSettings = loadSettings(os.path.join(env.configPath, globalSettings['fileContainingLogCollectionForJobsSettings']))
 		self.secondsBetweenLogCleanup = int(self.localSettings['waitHoursBetweenLogCleanupChecks']) * 60 * 60
 		self.secondsToRetainLogFiles = int(self.localSettings['numberOfHoursToRetainLogFiles']) * 60 * 60
+
+		## Twisted import here to avoid issues with epoll on Linux
+		from twisted.internet import task
 
 		## Make checking kafka and processing results a looping call, to give a
 		## break to the main reactor thread; otherwise it blocks other looping

--- a/ocp/framework/service/logCollectionService.py
+++ b/ocp/framework/service/logCollectionService.py
@@ -25,7 +25,6 @@ import sys
 import traceback
 from contextlib import suppress
 import twisted.logger
-from twisted.internet import reactor, task, defer, threads
 
 ## Add openContentPlatform directories onto the sys path
 import env
@@ -50,6 +49,9 @@ class LogCollection(localService.LocalService):
 		self.logger.info('Started logger for {serviceName!r}', serviceName=serviceName)
 		super().__init__(serviceName, globalSettings)
 		self.localSettings = loadSettings(os.path.join(env.configPath, globalSettings['fileContainingLogCollectionSettings']))
+
+		## Twisted import here to avoid issues with epoll on Linux
+		from twisted.internet import task
 
 		## Make checking kafka and processing results a looping call, to give a
 		## break to the main reactor thread; otherwise it blocks other looping

--- a/ocp/framework/service/networkService.py
+++ b/ocp/framework/service/networkService.py
@@ -34,12 +34,12 @@ import requests
 import multiprocessing
 import logging, logging.handlers
 from contextlib import suppress
-from twisted.internet import reactor, task, defer, ssl, threads
 from twisted.internet.protocol import ServerFactory
 from twisted.protocols.basic import LineReceiver
 from twisted.python.filepath import FilePath
 from sqlalchemy import exc
 from confluent_kafka import KafkaError
+from twisted.internet import threads
 
 ## Add openContentPlatform directories onto the sys path
 frameworkPath = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
@@ -308,6 +308,9 @@ class ServiceFactory(CoreService, ServerFactory):
 
 	def __init__(self, serviceName, globalSettings, hasClients=True, getDbClient=True):
 		"""Constructor for the ServiceFactory."""
+		## Twisted import here to avoid issues with epoll on Linux
+		from twisted.internet import task
+
 		## Need to call both inherented constructors with different args, which
 		## means using 'super' won't work unless *args and **kwargs are handled:
 		##   super().__init__(serviceName, globalSettings, getDbClient)
@@ -790,6 +793,9 @@ class ServiceProcess(multiprocessing.Process):
 
 		"""
 		try:
+			## Twisted import here to avoid issues with epoll on Linux
+			from twisted.internet import reactor, ssl
+
 			## There are two types of event handlers being used here:
 			##   self.shutdownEvent : main process tells this one to shutdown
 			##                        (e.g. on a Ctrl+C type event)

--- a/ocp/framework/service/queryService.py
+++ b/ocp/framework/service/queryService.py
@@ -27,7 +27,6 @@ import datetime
 import time
 from contextlib import suppress
 import twisted.logger
-from twisted.internet import reactor, task, defer, threads
 
 ## Add openContentPlatform directories onto the sys path
 import env
@@ -64,6 +63,9 @@ class Query(localService.LocalService):
 
 		self.localSettings = utils.loadSettings(os.path.join(env.configPath, globalSettings['fileContainingQuerySettings']))
 		self.logger.info('waitSecondsBetweenCacheCleanupJobs: {secs!r}', secs=self.localSettings['waitSecondsBetweenCacheCleanupJobs'])
+
+		## Twisted import here to avoid issues with epoll on Linux
+		from twisted.internet import task, threads
 
 		## TODO: modify looping calls to use threads.deferToThread(); avoid
 		## time delays/waits from being blocking to the main reactor thread

--- a/ocp/framework/service/resultProcessingService.py
+++ b/ocp/framework/service/resultProcessingService.py
@@ -26,7 +26,6 @@ import json
 import twisted.logger
 import traceback
 from contextlib import suppress
-from twisted.internet import task
 
 ## Add openContentPlatform directories onto the sys path
 import env
@@ -78,6 +77,10 @@ class ResultProcessingFactory(networkService.ServiceFactory):
 		if self.canceledEvent.is_set() or self.shutdownEvent.is_set():
 			self.logger.error('Cancelling startup of {serviceName!r}', serviceName=serviceName)
 			return
+
+		## Twisted import here to avoid issues with epoll on Linux
+		from twisted.internet import task
+
 		self.loopingGetKafkaPartitionCount = task.LoopingCall(self.doGetKafkaPartitionCount)
 		self.loopingGetKafkaPartitionCount.start(self.localSettings['waitSecondsBetweenRequestingKafkaPartitionCount'])
 

--- a/ocp/framework/service/transportService.py
+++ b/ocp/framework/service/transportService.py
@@ -23,11 +23,6 @@ import os
 import sys
 import traceback
 from contextlib import suppress
-from twisted.internet import reactor, ssl
-from twisted.python.filepath import FilePath
-from twisted.web.server import Site
-from twisted.web.wsgi import WSGIResource
-from twisted.python.threadpool import ThreadPool
 import multiprocessing
 
 ## Different logger options
@@ -145,6 +140,13 @@ class TransportService(multiprocessing.Process):
 		"""
 		## Setup requested log handler
 		try:
+			## Twisted imports here to avoid issues with epoll on Linux
+			from twisted.internet import reactor, ssl
+			from twisted.python.filepath import FilePath
+			from twisted.web.server import Site
+			from twisted.web.wsgi import WSGIResource
+			from twisted.python.threadpool import ThreadPool
+
 			print('Starting {}'.format(self.serviceName))
 			self.getLocalLogger()
 			self.logger.info('Starting {}'.format(self.serviceName))


### PR DESCRIPTION
To avoid errors running the OCP server on Linux (which uses epoll reactor, as opposed to the select reactor on Windows), we needed to avoid any direct/indirect import statements that loaded the reactor prior to the child processes starting.  So all service side imports of Twisted libs and APScheduler libs referring to the reactor, are moved from the top of modules into the multiprocessing sections. This allows OCP to have multiple Twisted reactors controlled by a single parent process.