### PR TITLE
constructAndSendData to be synchronous operation

### DIFF
--- a/ocp/content/contentGathering/testCommand/script/test_local_shell.py
+++ b/ocp/content/contentGathering/testCommand/script/test_local_shell.py
@@ -45,7 +45,8 @@ def startJob(runtime):
 				else:
 					runtime.logger.debug(' command successful: {}'.format(command))
 				runtime.logger.debug('  stdOut: {stdOut!r}', stdOut=stdOut)
-				runtime.logger.debug('  stdError: {stdError!r}', stdError=stdError)
+				if stdError is not None:
+					runtime.logger.debug('  stdError: {stdError!r}', stdError=stdError)
 
 			## Update the runtime status to success
 			runtime.status(1)

--- a/ocp/framework/client/jobClient.py
+++ b/ocp/framework/client/jobClient.py
@@ -912,21 +912,21 @@ class JobClientFactory(coreClient.ServiceClientFactory):
 		jobName = content['jobName']
 		self.logger.debug('doRemoveJob for job {jobName!r}', jobName=jobName)
 		## For debugging purposes:
-		self.logger.debug('  self.jobEndpoints.keys: {data!r}', data=self.jobEndpoints.keys())
-		if jobName in self.jobEndpoints.keys():
-			self.logger.debug('    self.jobEndpoints[jobName]: {data!r}', data=self.jobEndpoints[jobName])
-		self.logger.debug('  self.jobStatistics.keys: {data!r}', data=self.jobStatistics.keys())
-		if jobName in self.jobStatistics.keys():
-			self.logger.debug('    self.jobStatistics[jobName]: {data!r}', data=self.jobStatistics[jobName])
-		self.logger.debug('  self.jobThreads.keys: {data!r}', data=self.jobThreads.keys())
-		if jobName in self.jobThreads.keys():
-			self.logger.debug('    self.jobThreads[jobName]: {data!r}', data=self.jobThreads[jobName])
-		self.logger.debug('  self.jobEndpointsLoaded.keys: {data!r}', data=self.jobEndpointsLoaded.keys())
+		# self.logger.debug('  jobEndpoints.keys: {data!r}', data=self.jobEndpoints.keys())
+		# if jobName in self.jobEndpoints.keys():
+		# 	self.logger.debug('    jobEndpoints[jobName]: {data!r}', data=self.jobEndpoints[jobName])
+		# self.logger.debug('  jobStatistics.keys: {data!r}', data=self.jobStatistics.keys())
+		# if jobName in self.jobStatistics.keys():
+		# 	self.logger.debug('    jobStatistics[jobName]: {data!r}', data=self.jobStatistics[jobName])
+		# self.logger.debug('  jobThreads.keys: {data!r}', data=self.jobThreads.keys())
+		# if jobName in self.jobThreads.keys():
+		# 	self.logger.debug('    jobThreads: {data!r}', data=self.jobThreads[jobName])
+		# self.logger.debug('  jobEndpointsLoaded.keys: {data!r}', data=self.jobEndpointsLoaded.keys())
 		if jobName in self.jobEndpointsLoaded.keys():
-			self.logger.debug('    self.jobEndpointsLoaded[jobName]: {data!r}', data=self.jobEndpointsLoaded[jobName])
-		self.logger.debug('  self.jobEndpointsCount.keys: {data!r}', data=self.jobEndpointsCount.keys())
+			self.logger.debug('    jobEndpointsLoaded: {data!r}', data=self.jobEndpointsLoaded[jobName])
+		# self.logger.debug('  self.jobEndpointsCount.keys: {data!r}', data=self.jobEndpointsCount.keys())
 		if jobName in self.jobEndpointsCount.keys():
-			self.logger.debug('    self.jobEndpointsCount[jobName]: {data!r}', data=self.jobEndpointsCount[jobName])
+			self.logger.debug('    jobEndpointsCount: {data!r}', data=self.jobEndpointsCount[jobName])
 
 		## Gracefully close all threads via notification
 		if jobName not in self.jobThreads:


### PR DESCRIPTION
Main change here is to make service-to-client communication happen synchronously, so that multiple jobs running at the same time (called in non-reactor threads) will not undesirably merge partial data on the sendLine operation. This is rare but was noticed, hence the fix.  Note that due to the issues with epoll on Linux, the constructAndSendData function has to check if the reactor is loaded every time (via import statement)... which hopefully can be pulled out of here later.