### PR TITLE
Add showCommandParsing flag to dynamic discovery

### DIFF
--- a/ocp/content/contentGathering/dynamicDiscovery/job/powershell_app_components_base.json
+++ b/ocp/content/contentGathering/dynamicDiscovery/job/powershell_app_components_base.json
@@ -2,8 +2,12 @@
 	"jobName" : "powershell_app_components_base",
 	"realm" : "default",
 	"clientGroup" : "default",
+	"credentialGroup": "default",
 	"protocolType" : "ProtocolPowerShell",
 	"numberOfJobThreads" : 20,
+	"endpointPipeline": "service",
+	"endpointChunkSize": 20,
+	"endpointQueueSize": 40,
 	"jobScript" : "shell_app_components_base",
 	"endpointQuery" : "powershell_with_node_process",
 	"endpointIdColumn" : "ipaddress",
@@ -18,7 +22,8 @@
 		"maxCommandTime" : 60
 	},
 	"inputParameters" : {
-		"printDebug" : false
+		"printDebug" : false,
+		"showCommandParsing" : false
 	},
 	"triggerType" : "cron",
 	"triggerArgs" : {

--- a/ocp/content/contentGathering/dynamicDiscovery/job/powershell_app_components_base_test.json
+++ b/ocp/content/contentGathering/dynamicDiscovery/job/powershell_app_components_base_test.json
@@ -2,8 +2,12 @@
 	"jobName" : "powershell_app_components_base_test",
 	"realm" : "default",
 	"clientGroup" : "default",
+	"credentialGroup": "default",
 	"protocolType" : "ProtocolPowerShell",
 	"numberOfJobThreads" : 1,
+	"endpointPipeline": "service",
+	"endpointChunkSize": 20,
+	"endpointQueueSize": 40,
 	"jobScript" : "shell_app_components_base",
 	"endpointQuery" : "powershell_with_node_process",
 	"endpointIdColumn" : "ipaddress",
@@ -19,7 +23,8 @@
 		"maxCommandTime" : 60
 	},
 	"inputParameters" : {
-		"printDebug" : false
+		"printDebug" : false,
+		"showCommandParsing" : false
 	},
 	"triggerType" : "cron",
 	"triggerArgs" : {

--- a/ocp/content/contentGathering/dynamicDiscovery/job/powershell_app_components_vocal.json
+++ b/ocp/content/contentGathering/dynamicDiscovery/job/powershell_app_components_vocal.json
@@ -2,8 +2,12 @@
 	"jobName" : "powershell_app_components_vocal",
 	"realm" : "default",
 	"clientGroup" : "default",
+	"credentialGroup": "default",
 	"protocolType" : "ProtocolPowerShell",
-	"numberOfJobThreads" : 10,
+	"numberOfJobThreads" : 20,
+	"endpointPipeline": "service",
+	"endpointChunkSize": 20,
+	"endpointQueueSize": 40,
 	"jobScript" : "shell_app_components_vocal",
 	"endpointQuery" : "powershell_with_node_process_ips",
 	"endpointIdColumn" : "ipaddress",
@@ -18,7 +22,8 @@
 		"maxCommandTime" : 60
 	},
 	"inputParameters" : {
-		"printDebug" : false
+		"printDebug" : false,
+		"showCommandParsing" : false
 	},
 	"triggerType" : "cron",
 	"triggerArgs" : {

--- a/ocp/content/contentGathering/dynamicDiscovery/job/powershell_app_components_vocal_test.json
+++ b/ocp/content/contentGathering/dynamicDiscovery/job/powershell_app_components_vocal_test.json
@@ -2,8 +2,12 @@
 	"jobName" : "powershell_app_components_vocal_test",
 	"realm" : "default",
 	"clientGroup" : "default",
+	"credentialGroup": "default",
 	"protocolType" : "ProtocolPowerShell",
 	"numberOfJobThreads" : 1,
+	"endpointPipeline": "service",
+	"endpointChunkSize": 20,
+	"endpointQueueSize": 40,
 	"jobScript" : "shell_app_components_vocal",
 	"endpointQuery" : "powershell_with_node_process_ips",
 	"endpointIdColumn" : "ipaddress",
@@ -19,7 +23,8 @@
 		"maxCommandTime" : 60
 	},
 	"inputParameters" : {
-		"printDebug" : true
+		"printDebug" : true,
+		"showCommandParsing" : false
 	},
 	"triggerType" : "cron",
 	"triggerArgs" : {

--- a/ocp/content/contentGathering/dynamicDiscovery/job/ssh_app_components_base.json
+++ b/ocp/content/contentGathering/dynamicDiscovery/job/ssh_app_components_base.json
@@ -2,8 +2,12 @@
 	"jobName" : "ssh_app_components_base",
 	"realm" : "default",
 	"clientGroup" : "default",
+	"credentialGroup": "default",
 	"protocolType" : "ProtocolSsh",
-	"numberOfJobThreads" : 20	,
+	"numberOfJobThreads" : 20,
+	"endpointPipeline": "service",
+	"endpointChunkSize": 20,
+	"endpointQueueSize": 40,
 	"jobScript" : "shell_app_components_base",
 	"endpointQuery" : "ssh_with_node_process",
 	"endpointIdColumn" : "ipaddress",
@@ -18,7 +22,8 @@
 		"maxCommandTime" : 60
 	},
 	"inputParameters" : {
-		"printDebug" : false
+		"printDebug" : false,
+		"showCommandParsing" : false
 	},
 	"triggerType" : "cron",
 	"triggerArgs" : {
@@ -28,7 +33,7 @@
 		"week" : null,
 		"day_of_week" : null,
 		"hour" : "4,9,14,19",
-		"minute" : 3,
+		"minute" : 33,
 		"second" : null,
 		"start_date" : "",
 		"end_date" : ""

--- a/ocp/content/contentGathering/dynamicDiscovery/job/ssh_app_components_base_test.json
+++ b/ocp/content/contentGathering/dynamicDiscovery/job/ssh_app_components_base_test.json
@@ -2,8 +2,12 @@
 	"jobName" : "ssh_app_components_base_test",
 	"realm" : "default",
 	"clientGroup" : "default",
+	"credentialGroup": "default",
 	"protocolType" : "ProtocolSsh",
 	"numberOfJobThreads" : 1,
+	"endpointPipeline": "service",
+	"endpointChunkSize": 20,
+	"endpointQueueSize": 40,
 	"jobScript" : "shell_app_components_base",
 	"endpointQuery" : "ssh_with_node_process",
 	"endpointIdColumn" : "ipaddress",
@@ -19,7 +23,8 @@
 		"maxCommandTime" : 60
 	},
 	"inputParameters" : {
-		"printDebug" : false
+		"printDebug" : false,
+		"showCommandParsing" : false
 	},
 	"triggerType" : "cron",
 	"triggerArgs" : {

--- a/ocp/content/contentGathering/dynamicDiscovery/job/ssh_app_components_vocal.json
+++ b/ocp/content/contentGathering/dynamicDiscovery/job/ssh_app_components_vocal.json
@@ -2,8 +2,12 @@
 	"jobName" : "ssh_app_components_vocal",
 	"realm" : "default",
 	"clientGroup" : "default",
+	"credentialGroup": "default",
 	"protocolType" : "ProtocolSsh",
-	"numberOfJobThreads" : 1,
+	"numberOfJobThreads" : 20,
+	"endpointPipeline": "service",
+	"endpointChunkSize": 20,
+	"endpointQueueSize": 40,
 	"jobScript" : "shell_app_components_vocal",
 	"endpointQuery" : "ssh_with_node_process_ips",
 	"endpointIdColumn" : "ipaddress",
@@ -18,7 +22,8 @@
 		"maxCommandTime" : 60
 	},
 	"inputParameters" : {
-		"printDebug" : false
+		"printDebug" : false,
+		"showCommandParsing" : false
 	},
 	"triggerType" : "cron",
 	"triggerArgs" : {
@@ -28,7 +33,7 @@
 		"week" : null,
 		"day_of_week" : null,
 		"hour" : "6,11,16,21",
-		"minute" : 3,
+		"minute" : 33,
 		"second" : null,
 		"start_date" : "",
 		"end_date" : ""

--- a/ocp/content/contentGathering/dynamicDiscovery/job/ssh_app_components_vocal_test.json
+++ b/ocp/content/contentGathering/dynamicDiscovery/job/ssh_app_components_vocal_test.json
@@ -2,10 +2,14 @@
 	"jobName" : "ssh_app_components_vocal_test",
 	"realm" : "default",
 	"clientGroup" : "default",
+	"credentialGroup": "default",
 	"protocolType" : "ProtocolSsh",
 	"numberOfJobThreads" : 1,
+	"endpointPipeline": "service",
+	"endpointChunkSize": 20,
+	"endpointQueueSize": 40,
 	"jobScript" : "shell_app_components_vocal",
-	"endpointQuery" : "ssh_with_node_process_ips_test",
+	"endpointQuery" : "ssh_with_node_process_ips",
 	"endpointIdColumn" : "ipaddress",
 	"endpointAttrForRealmCheck": "ipaddress",
 	"createExecutionLog": false,
@@ -19,7 +23,8 @@
 		"maxCommandTime" : 60
 	},
 	"inputParameters" : {
-		"printDebug" : false
+		"printDebug" : false,
+		"showCommandParsing" : false
 	},
 	"triggerType" : "cron",
 	"triggerArgs" : {

--- a/ocp/content/contentGathering/dynamicDiscovery/script/shell_app_components_base.py
+++ b/ocp/content/contentGathering/dynamicDiscovery/script/shell_app_components_base.py
@@ -45,7 +45,8 @@ def standardBaseSetup(runtime, data):
 
 	## Get Processes
 	runtime.logger.report(' retrieving Processes...')
-	runtime.logger.setFlag(False)
+	showCommandParsing = runtime.parameters.get('showCommandParsing', False)
+	runtime.logger.setFlag(showCommandParsing)
 	shellAppComponentsUtils.getRawProcesses(runtime, data)
 	runtime.logger.setFlag(data.savedPrintDebug)
 

--- a/ocp/content/contentGathering/dynamicDiscovery/script/shell_app_components_vocal.py
+++ b/ocp/content/contentGathering/dynamicDiscovery/script/shell_app_components_vocal.py
@@ -525,13 +525,14 @@ def standardVocalSetup(runtime, data):
 
 	## Get Processes
 	runtime.logger.report(' retrieving Processes...')
-	runtime.logger.setFlag(False)
+	showCommandParsing = runtime.parameters.get('showCommandParsing', False)
+	runtime.logger.setFlag(showCommandParsing)
 	shellAppComponentsUtils.getRawProcesses(runtime, data)
 	runtime.logger.setFlag(data.savedPrintDebug)
 
 	## Get Network activity
 	runtime.logger.report(' retrieving Network...')
-	runtime.logger.setFlag(False)
+	runtime.logger.setFlag(showCommandParsing)
 	(data.udpListenerList, data.tcpListenerList, data.tcpEstablishedList) = osNetworkStack.getNetworkStack(runtime, data.client, data.protocolIp, localIpList=data.ipList, trackResults=False, hostname=data.nodeName, domain=data.nodeDomain)
 	runtime.logger.setFlag(data.savedPrintDebug)
 

--- a/ocp/content/contentGathering/shared/script/osNetworkStack.py
+++ b/ocp/content/contentGathering/shared/script/osNetworkStack.py
@@ -931,9 +931,9 @@ def discoverEstablishedConnections(runtime, client, outputString, osType, localI
 	## If most the lines returned with empty values for proc; report to the GUI
 	if (errorCount > 2 and errorCount / (len(outputLines)) > .75):
 		runtime.logger.info(' Number of outputLines: {establishedLineCount!r} and number of errors: {establishedLineErrors!r}', establishedLineCount=str(len(outputLines)), establishedLineErrors=str(errorCount))
-		runtime.logger.info(' Gathering established network connections returned partial data, which suggests limited access. Should this be run with elevated rights?')
+		runtime.logger.info(' Gathering established network connections returned partial data, which suggests limited access. Was this run with elevated rights?')
 		## Don't just warn; abort the run
-		raise EnvironmentError('Gathering established network connections returned partial data, which suggests limited access. Should this be run with elevated rights?')
+		raise EnvironmentError('Gathering established network connections returned partial data, which suggests limited access. Was this run with elevated rights?')
 
 	## Memory management for large queries
 	outputString = None


### PR DESCRIPTION
This exposes another input parameter to toggle showing the gathering and parsing of processes and network stack, which occurs in the shared scripts. Useful when doing deep troubleshooting.