### PR TITLE
Enforce name verification on universal job queries to API

### DIFF
--- a/ocp/content/universalJob/logicalModels/script/logicalModelUtils.py
+++ b/ocp/content/universalJob/logicalModels/script/logicalModelUtils.py
@@ -27,7 +27,7 @@ def getQueryResults(runtime, queryName, resultsFormat):
 	queryContent = None
 	with open(queryFile) as fp:
 		queryContent = json.load(fp)
-	queryResults = getApiQueryResultsFull(runtime, queryContent, resultsFormat=resultsFormat)
+	queryResults = getApiQueryResultsFull(runtime, queryContent, resultsFormat=resultsFormat, verify=runtime.ocpCertFile)
 
 	## end getQueryResults
 	return queryResults

--- a/ocp/content/universalJob/normalizeSoftware/script/normalize_job.py
+++ b/ocp/content/universalJob/normalizeSoftware/script/normalize_job.py
@@ -277,7 +277,7 @@ def startJob(runtime):
 				inputFile = loadJsonFile(os.path.join(inputPath, inputName + '.json'), 'input')
 				transformFile = loadJsonFile(os.path.join(transformPath, transformName + '.json'), 'transform')
 				## Query API for the query result
-				queryResults = getApiQueryResultsFull(runtime, inputFile, resultsFormat='Nested-Simple', headers={'removeEmptyAttributes': False})
+				queryResults = getApiQueryResultsFull(runtime, inputFile, resultsFormat='Nested-Simple', headers={'removeEmptyAttributes': False}, verify=runtime.ocpCertFile)
 				if queryResults is None or len(queryResults) <= 0:
 					runtime.logger.report('No results found for input query {inputName!r}; skipping.', inputName=inputName)
 					continue

--- a/ocp/content/universalJob/reportWorkbook/script/report_workbook.py
+++ b/ocp/content/universalJob/reportWorkbook/script/report_workbook.py
@@ -148,7 +148,7 @@ def startJob(runtime):
 					queryContent = json.load(fp)
 
 				runtime.logger.report(' Requesting queryName {queryName!r}', queryName=queryName)
-				queryResults = getApiQueryResultsFull(runtime, queryContent, resultsFormat='Nested-Simple', headers={'removeEmptyAttributes': False})
+				queryResults = getApiQueryResultsFull(runtime, queryContent, resultsFormat='Nested-Simple', headers={'removeEmptyAttributes': False}, verify=runtime.ocpCertFile)
 				if queryResults is None or len(queryResults) <= 0:
 					runtime.logger.debug('No results found for queryName {queryName!r}', queryName=queryName)
 					continue

--- a/ocp/content/universalJob/strongObjectReference/script/merge_nodes_without_domain.py
+++ b/ocp/content/universalJob/strongObjectReference/script/merge_nodes_without_domain.py
@@ -78,7 +78,7 @@ def getQueryResults(runtime, queryName, resultsFormat):
 	queryContent = None
 	with open(queryFile) as fp:
 		queryContent = json.load(fp)
-	queryResults = getApiQueryResultsFull(runtime, queryContent, resultsFormat=resultsFormat)
+	queryResults = getApiQueryResultsFull(runtime, queryContent, resultsFormat=resultsFormat, verify=runtime.ocpCertFile)
 
 	## end getQueryResults
 	return queryResults


### PR DESCRIPTION
Just adding the verify certificate option to the requests call; the was previously committed across content gathering jobs, so this just does likewise on universal jobs