### PR TITLE
SNMP OID to object attribute mapping

### DIFF
--- a/ocp/content/contentGathering/shared/endpoint/snmp_with_node.json
+++ b/ocp/content/contentGathering/shared/endpoint/snmp_with_node.json
@@ -1,23 +1,23 @@
 {
 	"objects": [{
-			"class_name": "SSH",
-			"attributes": ["object_type", "ipaddress", "protocol_reference", "realm", "container", "node_type", "parameters"],
+			"class_name": "SNMP",
+			"attributes": ["object_type", "ipaddress", "protocol_reference", "realm", "container", "node_type"],
 			"minimum": "1",
 			"maximum": "",
 			"linchpin": true
 		},
 		{
 			"class_name": "Node",
-			"attributes": ["hostname", "domain"],
+			"attributes": ["hostname", "domain", "snmp_oid"],
 			"minimum": "1",
 			"maximum": "1"
 		}
 	],
 	"links": [{
-		"label": "NODE_TO_SHELL",
+		"label": "NODE_TO_SNMP",
 		"class_name": "Enclosed",
 		"attributes": [],
 		"first_id": "Node",
-		"second_id": "SSH"
+		"second_id": "SNMP"
 	}]
 }

--- a/ocp/content/contentGathering/shared/endpoint/snmp_with_node_hw.json
+++ b/ocp/content/contentGathering/shared/endpoint/snmp_with_node_hw.json
@@ -1,0 +1,36 @@
+{
+	"objects": [{
+			"class_name": "SNMP",
+			"attributes": ["object_type", "ipaddress", "protocol_reference", "realm", "container", "node_type"],
+			"minimum": "1",
+			"maximum": "",
+			"linchpin": true
+		},
+		{
+			"class_name": "Node",
+			"attributes": ["hostname", "domain", "snmp_oid"],
+			"minimum": "1",
+			"maximum": "1"
+		},
+		{
+			"class_name": "Hardware",
+			"attributes": ["vendor", "model", "version", "build", "asset_tag", "serial_number"],
+			"minimum": "0",
+			"maximum": ""
+		}
+	],
+	"links": [{
+		"label": "NODE_TO_SNMP",
+		"class_name": "Enclosed",
+		"attributes": [],
+		"first_id": "Node",
+		"second_id": "SNMP"
+	},
+	{
+		"label": "NODE_TO_HW",
+		"class_name": "Usage",
+		"attributes": [],
+		"first_id": "Node",
+		"second_id": "Hardware"
+	}]
+}

--- a/ocp/content/contentGathering/snmpMapping/conf/snmpOidToNodeAttributes.json
+++ b/ocp/content/contentGathering/snmpMapping/conf/snmpOidToNodeAttributes.json
@@ -1,0 +1,68 @@
+[
+	{
+		"deviceTypeForReferenceOnly": "Storage - QNAP",
+		"matchingSection": {
+			"snmpOID": "1.3.6.1.4.1.55062",
+			"comparisonOperator": "=="
+		},
+		"mappingSection": {
+			"1.3.6.1.4.1.55062.1.12.5": {
+				"samples": [],
+				"attributes": [{
+					"endpointQueryObject": "Hardware",
+					"objectType": "HardwareStorage",
+					"nodeAttribute": "serial_number",
+					"assignmentOperator": "=",
+					"overrideCurrentValues": false
+				}]
+			},
+			"1.3.6.1.4.1.55062.1.12.6": {
+				"samples": ["30H43", "30H44"],
+				"attributes": [{
+					"endpointQueryObject": "Hardware",
+					"objectType": "HardwareStorage",
+					"nodeAttribute": "version",
+					"assignmentOperator": "=",
+					"overrideCurrentValues": true
+				}]
+			}
+		}
+	},
+	{
+		"deviceTypeForReferenceOnly": "Printer - HP OfficeJet",
+		"matchingSection": {
+			"snmpOID": "1.3.6.1.4.1.11.2.3.9.1",
+			"comparisonOperator": "regEx",
+			"comparisonValue": "^snmpOID.*"
+		},
+		"mappingSection": {
+			"1.3.6.1.4.1.11.2.3.9.1.1.7.0" : {
+				"samples": [
+					"MFG:HP;MDL:OfficeJet Pro 7740 series;CMD:PCL3GUI,PCL3,PJL,Automatic,JPEG,PCLM,AppleRaster,PWGRaster,DW-PCL,802.11,802.3,DESKJET,DYN;CLS:PRINTER;DES:G5J38A;CID:HPIJVIPBV9;LEDMDIS:USB#FF#CC#00,USB#FF#04#01;SN:CN77A4506T;S:038080C48450000100580080000441d0014451d0014461d001441180046;Z:05000009000001000001000001000009,12000,17000000000045000045000055000000,181;"
+				],
+				"attributes": [{
+					"endpointQueryObject": "Hardware",
+					"objectType": "HardwarePrinter",
+					"nodeAttribute": "serial_number",
+					"assignmentOperator": "regEx",
+					"assignmentValue": ".*;SN[:]([^;]+);.*",
+					"overrideCurrentValues": false
+				},{
+					"endpointQueryObject": "Hardware",
+					"objectType": "HardwarePrinter",
+					"nodeAttribute": "model",
+					"assignmentOperator": "regEx",
+					"assignmentValue": ".*;MDL[:]([^;]+);.*",
+					"overrideCurrentValues": true
+				},{
+					"endpointQueryObject": "Node",
+					"objectType": "Printer",
+					"nodeAttribute": "platform",
+					"assignmentOperator": "regEx",
+					"assignmentValue": ".*;CLS[:]([^;]+);.*",
+					"overrideCurrentValues": false
+				}]
+			}
+		}
+	}
+]

--- a/ocp/content/contentGathering/snmpMapping/job/snmp_oid_to_attribute_mapping.json
+++ b/ocp/content/contentGathering/snmpMapping/job/snmp_oid_to_attribute_mapping.json
@@ -1,0 +1,40 @@
+{
+	"jobName" : "snmp_oid_to_attribute_mapping",
+	"realm" : "default",
+	"clientGroup" : "default",
+	"credentialGroup" : "default",
+	"protocolType" : "ProtocolSnmp",
+	"numberOfJobThreads" : 20,
+	"endpointPipeline": "service",
+	"endpointChunkSize" : 10,
+	"endpointQueueSize" : 40,
+	"jobScript" : "snmp_oid_to_attribute_mapping",
+	"endpointQuery" : "snmp_with_node_hw",
+	"endpointIdColumn" : "ipaddress",
+	"endpointAttrForRealmCheck": "ipaddress",
+	"createExecutionLog": false,
+	"isDisabled" : true,
+	"inputParameters" : {
+		"printDebug" : true,
+		"confFileWithMapping" : "snmpOidToNodeAttributes"
+	},
+	"triggerType" : "cron",
+	"triggerArgs" : {
+		"year" : null,
+		"month" : null,
+		"day" : null,
+		"week" : null,
+		"day_of_week" : null,
+		"hour" : "6,16",
+		"minute" : 2,
+		"second" : null,
+		"start_date" : "",
+		"end_date" : ""
+	},
+	"schedulerArgs" : {
+		"misfire_grace_time" : 10,
+		"coalesce" : 1,
+		"max_instances" : 1,
+		"replace_existing" : 1
+	}
+}

--- a/ocp/content/contentGathering/snmpMapping/script/snmp_oid_to_attribute_mapping.py
+++ b/ocp/content/contentGathering/snmpMapping/script/snmp_oid_to_attribute_mapping.py
@@ -1,0 +1,235 @@
+"""Update Node or Hardware CI attributes, based on OID mapping file.
+
+This enables quick mapping sections for private MIBs, but can also be used to
+regEx parse OID response from the public MIB space.
+
+
+Functions:
+  startJob : standard job entry point
+  getMappingFile : read JSON mapping file
+  processResults : get nodes & hardware objects and check for matches
+  processThisMappingSection : check for matches & update attributes
+  snmpGet : simple helper function
+
+Author: Chris Satterthwaite (CS)
+Contributors:
+Version info:
+  1.0 : (CS) Created May 28, 2021
+
+"""
+import sys
+import traceback
+import re
+import os
+import json
+from contextlib import suppress
+
+## From openContentPlatform
+from protocolWrapper import getClient
+from utilities import addObject, addLink
+
+
+def snmpGet(client, oid):
+	"""Simple helper function."""
+	snmpResponse = {}
+	client.get(oid, snmpResponse)
+	return snmpResponse.get(oid, None)
+
+
+def processThisMappingSection(runtime, client, mappingSection, objectTypes, prevNodeData, prevHardwareData, newNodeData, newHardwareData):
+	"""Process a mapping section; check for matches & update attributes."""
+	for oid,section in mappingSection.items():
+		## 'samples' are just for reference
+		attributes = section.get('attributes', [])
+		for attributeSection in attributes:
+			## Get the section attributes
+			endpointQueryObject = attributeSection.get('endpointQueryObject').lower()
+			objectType = attributeSection.get('objectType')
+			nodeAttribute = attributeSection.get('nodeAttribute')
+			assignmentOperator = attributeSection.get('assignmentOperator', '=').lower()
+			assignmentValue = attributeSection.get('assignmentValue')
+			overrideCurrentValues = attributeSection.get('overrideCurrentValues', False)
+			
+			## Attribute validation
+			if endpointQueryObject not in ['node', 'hardware']:
+				runtime.logger.warn('Unknown endpointQueryObject type for mapping {}. Received {} and expected either "Node" or "Hardware".'.format(ref, endpointQueryObject))
+				continue
+			if assignmentOperator not in ['=', 'regex']:
+				runtime.logger.warn('Unknown assignmentOperator type for mapping {}. Received {} and expected either "=" or "regEx".'.format(ref, assignmentOperator))
+				continue
+			
+			## Track Object type to create, when creating new
+			if endpointQueryObject not in objectTypes:
+				objectTypes[endpointQueryObject] = objectType
+			
+			## Issue an SNMP get
+			value = snmpGet(client, oid)
+			runtime.logger.report('  SNMP request: {}'.format(oid))
+			if value is None:
+				continue
+			runtime.logger.report('  SNMP response: {}'.format(value))
+			
+			## Skip if value is set and we aren't overriding current value
+			objectToUpdate = None
+			if not overrideCurrentValues:
+				if endpointQueryObject == 'hardware':
+					if nodeAttribute in prevHardwareData and prevHardwareData.get(nodeAttribute) is not None:
+						runtime.logger.report(' Hardware attribute {} already set: {}'.format(nodeAttribute, prevHardwareData.get('nodeAttribute')))
+						continue
+				else: ## endpointQueryObject == 'node'
+					if nodeAttribute in prevNodeData and prevNodeData.get(nodeAttribute) is not None:
+						runtime.logger.report(' Node attribute {} already set: {}'.format(nodeAttribute, prevNodeData.get('nodeAttribute')))
+						continue
+			
+			if assignmentOperator == '=':
+				if endpointQueryObject == 'hardware':
+					newHardwareData[nodeAttribute] = value
+				else:
+					newNodeData[nodeAttribute] = value
+			else: ## assignmentOperator == 'regEx'
+				m = re.search(assignmentValue, value)
+				if m:
+					parsedValue = m.groups()
+					if len(parsedValue) == 1:
+						parsedValue = m.group(1)
+					runtime.logger.report('  setting {}.{}: {}'.format(endpointQueryObject, nodeAttribute, parsedValue))
+					if endpointQueryObject == 'hardware':
+						newHardwareData[nodeAttribute] = parsedValue
+					else: ## endpointQueryObject == 'node'
+						newNodeData[nodeAttribute] = parsedValue
+				else:
+					runtime.logger.report('  no regEx match found for {}.{} on value: {}'.format(endpointQueryObject, nodeAttribute, value))
+
+	## end processThisMappingSection
+	return
+
+
+def processResults(runtime, client, mappingEntries):
+	"""Get nodes & hardware objects passed in and check for matches."""
+	try:
+		## Get node attributes coming in
+		identifier = runtime.endpoint.get('identifier')
+		node = runtime.endpoint.get('children').get('Node', [])[0]
+		prevNodeData = node.get('data', {})
+		nodeName = prevNodeData.get('hostname')
+		nodeId = node.get('identifier')
+		deviceOID = prevNodeData.get('snmp_oid')
+		runtime.logger.report('Processing node {} with snmp_oid {}'.format(nodeName, deviceOID))
+		if deviceOID is None:
+			raise ValueError('Node {} snmp_oid attribute is empty; cannot compare'.format(nodeName))
+		
+		## Get hardware attributes coming in
+		hardware = None
+		prevHardwareData = {}
+		hardwareId = None
+		nodeHardwareList = node.get('children').get('Hardware', [])
+		if len(nodeHardwareList) > 0:
+			hardware = nodeHardwareList[0]
+			prevHardwareData = hardware.get('data', {})
+			hardwareId = hardware.get('identifier')
+		
+		## Dictionaries for our attribute-to-value mapping here
+		newNodeData = {}
+		newHardwareData = {}
+		objectTypes = {}
+		foundMatch = False
+		
+		## Loop through the mapping entries
+		for entry in mappingEntries:
+			ref = entry.get('deviceTypeForReferenceOnly')
+			matchingSection = entry.get('matchingSection', {})
+			
+			## Matching section
+			snmpOID = matchingSection.get('snmpOID')
+			comparisonOperator = matchingSection.get('comparisonOperator')
+			comparisonValue = matchingSection.get('comparisonValue')
+			if comparisonOperator == '==': 
+				if deviceOID != snmpOID:
+					continue
+			elif comparisonOperator.lower() == 'regex':
+				escapedOID = snmpOID.replace('.', '[.]')
+				value = comparisonValue.replace('snmpOID', escapedOID, re.I)
+				if not re.search(value, deviceOID):
+					continue
+			else:
+				runtime.logger.warn('Unknown compare type for mapping {}. Received {} and expected either "==" or "regEx".'.format(ref, comparisonOperator))
+				continue
+			
+			foundMatch = True
+			runtime.logger.report(' Matched section: {}'.format(ref))
+			
+			## Mapping section
+			mappingSection = entry.get('mappingSection', {})
+			processThisMappingSection(runtime, client, mappingSection, objectTypes, prevNodeData, prevHardwareData, newNodeData, newHardwareData)
+			
+			## We already matched
+			break
+		
+		if foundMatch:
+			## Update the objects/links
+			thisNode = None
+			thisHardware = None
+			if len(newNodeData) > 0:
+				## Update the node
+				thisNode, exists = addObject(runtime, 'Node', uniqueId=nodeId, **newNodeData)
+			if len(newHardwareData) > 0:
+				if hardwareId is None:
+					## Create a new hardware object
+					thisHardware, exists = addObject(runtime, objectTypes.get('hardware', 'Hardware'), **newHardwareData)
+				else:
+					## Update the previous hardware
+					thisHardware, exists = addObject(runtime, objectTypes.get('Hardware'), uniqueId=hardwareId, **newHardwareData)
+				addLink(runtime, 'Usage', thisNode, thisHardware)
+
+		else:
+			runtime.logger.report('No match found on node {} with snmp_oid {}'.format(nodeName, deviceOID))
+			runtime.setInfo('No match found on node {} with snmp_oid {}'.format(nodeName, deviceOID))
+
+	except:
+		runtime.setError(__name__)
+
+	## end processResults
+	return
+
+
+def getMappingFile(runtime, mappingFileName):
+	"""Check if JSON file exists and read contents."""
+	mappingFile = os.path.join(runtime.env.contentGatheringPkgPath, 'snmpMapping', 'conf', mappingFileName + '.json')
+	if not os.path.isfile(mappingFile):
+		raise EnvironmentError('Missing conf file specified in the parameters: {}.json'.format(mappingFile))
+
+	mappingEntries = None
+	with open(mappingFile) as fp:
+		mappingEntries = json.load(fp)
+
+	## end getMappingFile
+	return mappingEntries
+
+
+def startJob(runtime):
+	"""Standard job entry point.
+
+	Arguments:
+	  runtime (dict)   : object used for providing input into jobs and tracking
+	                     the job thread through the life of its runtime.
+	"""
+	try:
+		## Get mapping file
+		mappingFileName = runtime.parameters.get('confFileWithMapping')
+		mappingEntries = getMappingFile(runtime, mappingFileName)
+		
+		## Configure snmp client
+		client = getClient(runtime)
+		
+		## Do the work
+		processResults(runtime, client, mappingEntries)
+
+		## Update the runtime status to success
+		if runtime.getStatus() == 'UNKNOWN':
+			runtime.status(1)
+
+	except:
+		runtime.setError(__name__)
+
+	## end startJob
+	return

--- a/ocp/content/universalJob/subTypeNodes/conf/snmpOidToNodeSubTypes.json
+++ b/ocp/content/universalJob/subTypeNodes/conf/snmpOidToNodeSubTypes.json
@@ -1,6 +1,22 @@
 [
 	{
-		"deviceTypeForReferenceOnly": "QNAP Storage device",
+		"deviceTypeForReferenceOnly": "Management Card - HP iLO",
+		"matchingSection": {
+			"snmpOID": "1.3.6.1.4.1.232.9.4.10",
+			"compareType": "regEx",
+			"compareValue": "^snmpOID.*"
+		},
+		"mappingSection": {
+			"type": "ManagementInterface",
+			"attributeValueOverrides": {},
+			"attributeValuesToUseWhenEmpty": {
+				"vendor": "HP",
+				"description": "HP iLO management card"
+			}
+		}
+	},
+	{
+		"deviceTypeForReferenceOnly": "Storage - QNAP",
 		"matchingSection": {
 			"snmpOID": "1.3.6.1.4.1.55062",
 			"compareType": "==",
@@ -10,12 +26,29 @@
 			"type": "Storage",
 			"attributeValueOverrides": {},
 			"attributeValuesToUseWhenEmpty": {
-				"vendor": "QNAP Storage, Inc."
+				"vendor": "QNAP Storage, Inc.",
+				"description": "QNAP storage device"
 			}
 		}
 	},
 	{
-		"deviceTypeForReferenceOnly": "HP printer - OfficeJet Pro",
+		"deviceTypeForReferenceOnly": "Storage - HP 3PAR",
+		"matchingSection": {
+			"snmpOID": "1.3.6.1.4.1.12925.1",
+			"compareType": "regEx",
+			"compareValue": "^snmpOID.*"
+		},
+		"mappingSection": {
+			"type": "Storage",
+			"attributeValueOverrides": {},
+			"attributeValuesToUseWhenEmpty": {
+				"vendor": "HP",
+				"description": "HP 3PAR storage device"
+			}
+		}
+	},
+	{
+		"deviceTypeForReferenceOnly": "Printer - HP OfficeJet",
 		"matchingSection": {
 			"snmpOID": "1.3.6.1.4.1.11.2.3.9.1",
 			"compareType": "regEx",

--- a/ocp/content/universalJob/subTypeNodes/script/subtype_nodes_via_snmp_oid_mapping.py
+++ b/ocp/content/universalJob/subTypeNodes/script/subtype_nodes_via_snmp_oid_mapping.py
@@ -72,7 +72,7 @@ def processResults(runtime, mappingEntries, queryContent):
 				attributeValuesToUseWhenEmpty = mappingSection.get('attributeValuesToUseWhenEmpty', {})
 				
 				attrs = {}
-				## Explicitely set domain to null if it was null before
+				## Explicitly set domain to null if it was null before
 				nodeDomain = nodeData.get('domain')
 				attrs['hostname'] = nodeName
 				attrs['domain'] = nodeDomain

--- a/ocp/framework/database/schema/node.py
+++ b/ocp/framework/database/schema/node.py
@@ -306,3 +306,18 @@ class Storage(NodeDevice):
 	__table_args__ = {"schema":"data"}
 	object_id = Column(None, ForeignKey(NodeDevice.object_id), primary_key=True)
 	__mapper_args__ = {'with_polymorphic': '*', 'polymorphic_identity':'node_storage', 'inherit_condition': object_id == NodeDevice.object_id}
+
+
+class ManagementInterface(NodeDevice):
+	"""Defines a node_mgmt_interface object for the database.
+
+	Table :
+	  |  node_mgmt_interface
+	Columns:
+	  |  object_id [CHAR(32)] FK(node_server.object_id) PK
+	"""
+
+	__tablename__ = 'node_mgmt_interface'
+	__table_args__ = {"schema":"data"}
+	object_id = Column(None, ForeignKey(NodeDevice.object_id), primary_key=True)
+	__mapper_args__ = {'with_polymorphic': '*', 'polymorphic_identity':'node_mgmt_interface', 'inherit_condition': object_id == NodeDevice.object_id}


### PR DESCRIPTION
New content gathering package, with associated changes.  This enables quick mapping sections for private MIBs, but can also be used with regEx to parse out OID responses from the public MIB space.  Create/update Hardware/Node objects and attributes.